### PR TITLE
use img tag to include img in Readme

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -94,7 +94,7 @@ knitr::read_chunk(
 You can also use `sortable_js()` to drag and drop other widgets:
 
 <center>
-![](man/figures/diagrammer.gif)
+<img src="man/figures/diagrammer.gif" style = 'width:500px;'></img>
 </center>
 
 ```{r, eval=FALSE}

--- a/Readme.md
+++ b/Readme.md
@@ -61,10 +61,46 @@ You can create a drag-and-drop input object in Shiny, using the
 
 </center>
 
-    #> Warning in file(con, "r"): file("") accepte seulement open = "w+" et open =
-    #> "w+b" : utilisation du premier
-    #> Warning in knitr::read_chunk(system.file("shiny-examples/rank_list/app.R", :
-    #> code is empty
+``` r
+## Example shiny app with rank list
+
+library(shiny)
+library(sortable)
+
+ui <- fluidPage(
+  fluidRow(
+    column(
+      width = 12,
+      tags$b("Exercise"),
+      rank_list(
+        text = "Drag the items in any desired order",
+        labels = list(
+          "one",
+          "two",
+          "three",
+          htmltools::tags$div(
+            htmltools::em("Complex"), " html tag without a name"
+          ),
+          "five" = htmltools::tags$div(
+            htmltools::em("Complex"), " html tag with name: 'five'"
+          )
+        ),
+        input_id = "rank_list_1"
+      ),
+      tags$b("Result"),
+      verbatimTextOutput("results")
+    )
+  )
+)
+
+server <- function(input, output) {
+  output$results <- renderPrint({
+    input$rank_list_1 # This matches the input_id of the rank list
+  })
+}
+
+shinyApp(ui, server)
+```
 
 ### Bucket list
 
@@ -78,10 +114,86 @@ students to classify objects into multiple categories.
 
 </center>
 
-    #> Warning in file(con, "r"): file("") accepte seulement open = "w+" et open =
-    #> "w+b" : utilisation du premier
-    #> Warning in knitr::read_chunk(system.file("shiny-examples/bucket_list/app.R", :
-    #> code is empty
+``` r
+## Example shiny app with bucket list
+
+library(shiny)
+library(sortable)
+
+
+ui <- fluidPage(
+  tags$head(
+    tags$style(HTML(".bucket-list-container {min-height: 350px;}"))
+  ),
+  fluidRow(
+    column(
+      tags$b("Exercise"),
+      width = 12,
+      bucket_list(
+        header = "Drag the items in any desired bucket",
+        group_name = "bucket_list_group",
+        orientation = "horizontal",
+        add_rank_list(
+          text = "Drag from here",
+          labels = list(
+            "one",
+            "two",
+            "three",
+            htmltools::tags$div(
+              htmltools::em("Complex"), " html tag without a name"
+            ),
+            "five" = htmltools::tags$div(
+              htmltools::em("Complex"), " html tag with name: 'five'"
+            )
+          ),
+          input_id = "rank_list_1"
+        ),
+        add_rank_list(
+          text = "to here",
+          labels = NULL,
+          input_id = "rank_list_2"
+        )
+      )
+    )
+  ),
+  fluidRow(
+    column(
+      width = 12,
+      tags$b("Result"),
+      column(
+        width = 12,
+
+        tags$p("input$rank_list_1"),
+        verbatimTextOutput("results_1"),
+
+        tags$p("input$rank_list_2"),
+        verbatimTextOutput("results_2"),
+
+        tags$p("input$bucket_list_group"),
+        verbatimTextOutput("results_3")
+      )
+    )
+  )
+)
+
+server <- function(input,output) {
+  output$results_1 <-
+    renderPrint(
+      input$rank_list_1 # This matches the input_id of the first rank list
+    )
+  output$results_2 <-
+    renderPrint(
+      input$rank_list_2 # This matches the input_id of the second rank list
+    )
+  output$results_3 <-
+    renderPrint(
+      input$bucket_list_group # Matches the group_name of the bucket list
+    )
+}
+
+
+shinyApp(ui, server)
+```
 
 ### Add drag-and-drop to any HTML element
 

--- a/Readme.md
+++ b/Readme.md
@@ -61,46 +61,10 @@ You can create a drag-and-drop input object in Shiny, using the
 
 </center>
 
-``` r
-## Example shiny app with rank list
-
-library(shiny)
-library(sortable)
-
-ui <- fluidPage(
-  fluidRow(
-    column(
-      width = 12,
-      tags$b("Exercise"),
-      rank_list(
-        text = "Drag the items in any desired order",
-        labels = list(
-          "one",
-          "two",
-          "three",
-          htmltools::tags$div(
-            htmltools::em("Complex"), " html tag without a name"
-          ),
-          "five" = htmltools::tags$div(
-            htmltools::em("Complex"), " html tag with name: 'five'"
-          )
-        ),
-        input_id = "rank_list_1"
-      ),
-      tags$b("Result"),
-      verbatimTextOutput("results")
-    )
-  )
-)
-
-server <- function(input, output) {
-  output$results <- renderPrint({
-    input$rank_list_1 # This matches the input_id of the rank list
-  })
-}
-
-shinyApp(ui, server)
-```
+    #> Warning in file(con, "r"): file("") accepte seulement open = "w+" et open =
+    #> "w+b" : utilisation du premier
+    #> Warning in knitr::read_chunk(system.file("shiny-examples/rank_list/app.R", :
+    #> code is empty
 
 ### Bucket list
 
@@ -114,86 +78,10 @@ students to classify objects into multiple categories.
 
 </center>
 
-``` r
-## Example shiny app with bucket list
-
-library(shiny)
-library(sortable)
-
-
-ui <- fluidPage(
-  tags$head(
-    tags$style(HTML(".bucket-list-container {min-height: 350px;}"))
-  ),
-  fluidRow(
-    column(
-      tags$b("Exercise"),
-      width = 12,
-      bucket_list(
-        header = "Drag the items in any desired bucket",
-        group_name = "bucket_list_group",
-        orientation = "horizontal",
-        add_rank_list(
-          text = "Drag from here",
-          labels = list(
-            "one",
-            "two",
-            "three",
-            htmltools::tags$div(
-              htmltools::em("Complex"), " html tag without a name"
-            ),
-            "five" = htmltools::tags$div(
-              htmltools::em("Complex"), " html tag with name: 'five'"
-            )
-          ),
-          input_id = "rank_list_1"
-        ),
-        add_rank_list(
-          text = "to here",
-          labels = NULL,
-          input_id = "rank_list_2"
-        )
-      )
-    )
-  ),
-  fluidRow(
-    column(
-      width = 12,
-      tags$b("Result"),
-      column(
-        width = 12,
-
-        tags$p("input$rank_list_1"),
-        verbatimTextOutput("results_1"),
-
-        tags$p("input$rank_list_2"),
-        verbatimTextOutput("results_2"),
-
-        tags$p("input$bucket_list_group"),
-        verbatimTextOutput("results_3")
-      )
-    )
-  )
-)
-
-server <- function(input,output) {
-  output$results_1 <-
-    renderPrint(
-      input$rank_list_1 # This matches the input_id of the first rank list
-    )
-  output$results_2 <-
-    renderPrint(
-      input$rank_list_2 # This matches the input_id of the second rank list
-    )
-  output$results_3 <-
-    renderPrint(
-      input$bucket_list_group # Matches the group_name of the bucket list
-    )
-}
-
-
-shinyApp(ui, server)
-```
+    #> Warning in file(con, "r"): file("") accepte seulement open = "w+" et open =
+    #> "w+b" : utilisation du premier
+    #> Warning in knitr::read_chunk(system.file("shiny-examples/bucket_list/app.R", :
+    #> code is empty
 
 ### Add drag-and-drop to any HTML element
 
@@ -201,7 +89,7 @@ You can also use `sortable_js()` to drag and drop other widgets:
 
 <center>
 
-![](man/figures/diagrammer.gif)
+<img src="man/figures/diagrammer.gif" style = 'width:500px;'></img>
 
 </center>
 


### PR DESCRIPTION
It seems that currently the image is not correctly included in README
![image](https://user-images.githubusercontent.com/6791940/69725878-81596800-111f-11ea-8692-51b633d825ed.png)

One fix is to replace the markdown syntax with the `img` tag as done before in the document.
I get that in dev pkgdown website locally
![image](https://user-images.githubusercontent.com/6791940/69725922-a221bd80-111f-11ea-9f7b-14a9085f7faa.png)
