### PR TITLE
Add horizontal layout for rank_list()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,6 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Language: en-US
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # sortable (development version)
 
+* Add ability to switch the orientation of `rank_list()` items to horizontal. #92
+
 # sortable 0.4.6
 
 ## Upgrade sortable.js

--- a/R/rank_list.R
+++ b/R/rank_list.R
@@ -28,6 +28,8 @@
 #'   `rank_list_id_1`, and will automatically increment for every `rank_list`.
 #' @param class A css class applied to the rank list.  This can be used to
 #'   define custom styling.
+#' @param orientation Set this to "horizontal" to get horizontal orientation of
+#'   the items.
 #' @template options
 #'
 #' @seealso [sortable_js], [bucket_list] and [question_rank]
@@ -51,11 +53,14 @@ rank_list <- function(
   input_id,
   css_id = NULL,
   options = sortable_options(),
+  orientation = c("vertical", "horizontal"),
   class = "default-sortable"
 ) {
   if (is.null(css_id)) {
     css_id <- increment_rank_list()
   }
+  orientation = match.arg(orientation)
+  if (orientation == "horizontal") class = paste0(class, " horizontal")
   assert_that(is_sortable_options(options))
   assert_that(is_input_id(input_id))
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ You can create a drag-and-drop input object in Shiny, using the
 `rank_list()` function.
 
 <center>
+
 <img src="man/figures/rank_list_shiny.gif" style = 'width:500px;'></img>
+
 </center>
 
 ``` r
@@ -153,7 +155,9 @@ object. This can be useful for bucketing tasks, e.g. asking your
 students to classify objects into multiple categories.
 
 <center>
+
 <img src="man/figures/bucket_list_shiny.gif" style = 'width:500px;'></img>
+
 </center>
 
 ``` r
@@ -242,7 +246,9 @@ shinyApp(ui, server)
 You can also use `sortable_js()` to drag and drop other widgets:
 
 <center>
+
 <img src="man/figures/diagrammer.gif" style = 'width:500px;'></img>
+
 </center>
 
 ``` r
@@ -272,20 +278,20 @@ html_print(tagList(
 
 I learnt about the following related work after starting on `sortable`:
 
--   The `esquisse` [package](https://github.com/dreamRs/esquisse):
-
+  - The `esquisse` [package](https://github.com/dreamRs/esquisse):
+    
     > “The purpose of this add-in is to let you explore your data
     > quickly to extract the information they hold. You can only create
     > simple plots, you won’t be able to use custom scales and all the
     > power of ggplot2.”
 
--   There is also the `shinyjqui`
+  - There is also the `shinyjqui`
     [package](https://yang-tang.github.io/shinyjqui/):
-
+    
     > “An R wrapper for jQuery UI javascript library. It allows user to
     > easily add interactions and animation effects to a shiny app.”
 
--   The `shinyDND`
+  - The `shinyDND`
     [package](https://cran.r-project.org/package=shinyDND):
-
+    
     > Adds functionality to create drag and drop div elements in shiny.

--- a/inst/htmlwidgets/plugins/sortable-rstudio/bucket_list.css
+++ b/inst/htmlwidgets/plugins/sortable-rstudio/bucket_list.css
@@ -20,4 +20,3 @@
 .default-sortable.bucket-list.bucket-list-vertical .rank-list-container {
   flex: 1 0 auto;
 }
-

--- a/inst/htmlwidgets/plugins/sortable-rstudio/rank_list.css
+++ b/inst/htmlwidgets/plugins/sortable-rstudio/rank_list.css
@@ -1,3 +1,11 @@
+.default-sortable.horizontal .rank-list {
+  display: flex;
+}
+
+.default-sortable.horizontal .rank-list-item {
+  flex-grow: 1;
+}
+
 .default-sortable.rank-list-container {
   flex: 1 0 200px;
   background-color: transparent;
@@ -60,4 +68,3 @@
 .default-sortable .rank-list-item.disabled {
   cursor: not-allowed;
 }
-

--- a/inst/htmlwidgets/plugins/sortable-rstudio/rank_list.scss
+++ b/inst/htmlwidgets/plugins/sortable-rstudio/rank_list.scss
@@ -1,5 +1,18 @@
 @import "colors";
 
+
+.default-sortable.horizontal {
+  & .rank-list {
+      display:flex; //horizontal
+  }
+
+  & .rank-list-item {
+    // width: 100px;
+    flex-grow: 1;
+  }
+}
+
+
 .default-sortable {
 
   &.rank-list-container {
@@ -16,8 +29,9 @@
     flex: 0 0 auto;
   }
 
+
   .rank-list {
-    flex: 1 0 auto;
+    flex: 1 0 auto;  // default
     -webkit-border-radius: 3px;
     border-radius: 5px;
     background-color: $item-color;
@@ -28,7 +42,9 @@
       border-style: dashed;
       border-color: $border-color;
     }
+
   }
+
 
   .rank-list-item {
     border-radius: $border-radius;
@@ -38,6 +54,9 @@
     border: 1px solid $border-color;
     overflow: hidden;
     // width: 100%;
+
+    // horizontal
+
 
     &:hover:not(.disabled) {
       background-color: $item-hover-color;

--- a/inst/shiny-examples/horizontal/app.R
+++ b/inst/shiny-examples/horizontal/app.R
@@ -1,16 +1,23 @@
 library(shiny)
 library(sortable)
 
+set.seed(123456) # to make sample() reproducible
+labels <- sample(month.name[1:5])
+
 ui <- fluidPage(
   div(
-    # style = "width: 500px", id = "my-ranklist",
     rank_list(
       text = "Horizontal rank list",
-      labels = c("/", "26", "2022", "August", "/"),
-      input_id = "rank",
-      orientation = "horizontal",
-      # class = "default-sortable horizontal"
-      class = "default-sortable"
+      labels = labels,
+      input_id = "rank_h",
+      orientation = "horizontal"
+    )
+  ),
+  div(
+    rank_list(
+      text = "Default rank list (vertical)",
+      labels = labels,
+      input_id = "rank"
     )
   )
 )

--- a/inst/shiny-examples/horizontal/app.R
+++ b/inst/shiny-examples/horizontal/app.R
@@ -1,0 +1,20 @@
+library(shiny)
+library(sortable)
+
+ui <- fluidPage(
+  div(
+    # style = "width: 500px", id = "my-ranklist",
+    rank_list(
+      text = "Horizontal rank list",
+      labels = c("/", "26", "2022", "August", "/"),
+      input_id = "rank",
+      orientation = "horizontal",
+      # class = "default-sortable horizontal"
+      class = "default-sortable"
+    )
+  )
+)
+
+server <- function(input, output, session) {}
+
+shinyApp(ui, server)

--- a/man/rank_list.Rd
+++ b/man/rank_list.Rd
@@ -10,6 +10,7 @@ rank_list(
   input_id,
   css_id = NULL,
   options = sortable_options(),
+  orientation = c("vertical", "horizontal"),
   class = "default-sortable"
 )
 }
@@ -27,6 +28,9 @@ app. If NULL, the function generates an id of the form
 \code{rank_list_id_1}, and will automatically increment for every \code{rank_list}.}
 
 \item{options}{Options to be supplied to \link{sortable_js} object. See \link{sortable_options} for more details}
+
+\item{orientation}{Set this to "horizontal" to get horizontal orientation of
+the items.}
 
 \item{class}{A css class applied to the rank list.  This can be used to
 define custom styling.}


### PR DESCRIPTION
This is what a horizontal `rank_list()` looks like

![image](https://user-images.githubusercontent.com/479998/225610862-dc58ee9f-2153-4a49-88b7-9e387c680287.png)

As produced by this example app that's in the `inst` folder:

``` r
library(shiny)
library(sortable)

set.seed(123456) # to make sample() reproducible
labels <- sample(month.name[1:5])

ui <- fluidPage(
  div(
    rank_list(
      text = "Horizontal rank list",
      labels = labels,
      input_id = "rank_h",
      orientation = "horizontal"
    )
  ),
  div(
    rank_list(
      text = "Default rank list (vertical)",
      labels = labels,
      input_id = "rank"
    )
  )
)

server <- function(input, output, session) {}

shinyApp(ui, server)
```

First requested in #92 