### PR TITLE
Update rank list

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "rPackageTask",
+			"problemMatcher": [],
+			"label": "R: Check R package",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	]
+}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: sortable
 Title: Drag-and-Drop in 'shiny' Apps with 'SortableJS'
-Version: 0.5.0
+Version: 0.5.0.9000
 Authors@R: 
     c(person(given = "Andrie",
              family = "de Vries",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,8 +38,7 @@ Imports:
     assertthat,
     jsonlite,
     utils,
-    rlang (>= 1.0.0),
-    ellipsis
+    rlang (>= 1.0.0)
 Suggests:
     base64enc,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     htmltools,
     htmlwidgets,
     learnr (>= 0.10.0),
-    shiny,
+    shiny (>= 1.9.0),
     assertthat,
     jsonlite,
     utils,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,6 +53,6 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Language: en-US
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,11 +4,15 @@
 
 * Update `Sortable.js` to version 1.15.3
 
+## Enhancements
+
+* New function `update_bucket_list()` to update the items in a bucket list
+
 # sortable 0.5.0
 
 ## Enhancements
 
-* Add support for `update_rank_list()` and `update_bucket_list()`
+* Add support for `update_rank_list()` 
 * Add ability to switch the orientation of `rank_list()` items to horizontal. #92
 
 ## Changes

--- a/R/bucket_list.R
+++ b/R/bucket_list.R
@@ -152,7 +152,7 @@ bucket_list <- function(
   z <- tagList(
     tags$div(
       class = paste("bucket-list-container", class),
-      id = paste0("bucket-list-", css_id),
+      id = as_bucket_list_id(css_id),
       title_tag,
       tags$div(
         class = paste(class, "bucket-list",

--- a/R/bucket_list.R
+++ b/R/bucket_list.R
@@ -103,7 +103,7 @@ bucket_list <- function(
   class <- paste(class, collapse = " ")
 
   # capture the dots
-  ellipsis::check_dots_unnamed()
+  rlang::check_dots_unnamed()
   dot_vals <- rlang::list2(...)
 
   # Remove any NULL elements

--- a/R/js.R
+++ b/R/js.R
@@ -48,7 +48,9 @@ sortable_js_capture_input <- function(input_id) {
   )
   js_text <- "function(evt) {
   if (typeof Shiny !== \"undefined\") {
-    Shiny.setInputValue(\"%s:sortablejs.rank_list\", %s)
+    Shiny.initializedPromise.then(() => {
+      Shiny.setInputValue(\"%s:sortablejs.rank_list\", %s)
+    });
   }
 }"
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -20,3 +20,18 @@ print.rank_list <- function(x, ...){
 print.bucket_list <- function(x, ...){
   htmltools::html_print(x)
 }
+
+
+# The names must be suffix values to allow for modules which use prefix values
+# https://github.com/rstudio/sortable/issues/100
+as_rank_list_id <- function(id) {
+  paste0("rank-list-", id)
+}
+# TODO: in future, change the order of paste, to enable shiny modules
+# paste0(id, "-rank-list")
+
+as_bucket_list_id <- function(id) {
+  paste0("bucket-list-", id)
+}
+# TODO: in future, change the order of paste, to enable shiny modules
+# paste0(id, "-bucket-list")

--- a/R/rank_list.R
+++ b/R/rank_list.R
@@ -1,3 +1,24 @@
+# Create label tags for rank_list
+as_label_tags <- function(labels) {
+  mapply(
+    USE.NAMES = FALSE,
+    SIMPLIFY = FALSE,
+    labels,
+    label_ids(labels),
+    FUN = function(label, label_id) {
+      if (identical(label_id, "")) {
+        label_id <- NULL
+      }
+      tags$div(
+        class = "rank-list-item",
+        "data-rank-id" = label_id,
+        label
+      )
+    }
+  )
+}
+
+
 #' Create a ranking item list.
 #'
 #' @description Creates a ranking item list using the `SortableJS` framework,
@@ -89,22 +110,7 @@ rank_list <- function(
     NULL
   }
 
-  label_tags <- mapply(
-    USE.NAMES = FALSE,
-    SIMPLIFY = FALSE,
-    labels,
-    label_ids(labels),
-    FUN = function(label, label_id) {
-      if (identical(label_id, "")) {
-        label_id <- NULL
-      }
-      tags$div(
-        class = "rank-list-item",
-        "data-rank-id" = label_id,
-        label
-      )
-    }
-  )
+  label_tags <- as_label_tags(labels)
 
   rank_list_tags <- tagList(
     tags$div(
@@ -153,11 +159,15 @@ dropNulls <- function(x) {
 #'   )
 #'   shiny::runApp(app)
 #' }
-update_rank_list <- function(css_id, text = NULL,
+update_rank_list <- function(css_id, text = NULL, labels = NULL,
                              session = shiny::getDefaultReactiveDomain()) {
   inputId <- paste0("rank-list-", css_id)
-  message <- dropNulls(list(id = inputId, text = text))
+  if ( !is.null(labels) && length(labels) > 0) {
+    labels <- as.character(tagList(as_label_tags(labels)))
+  }
+  message <- dropNulls(list(id = inputId, text = text, labels = labels))
   session$sendInputMessage(inputId, message)
+
 }
 
 

--- a/R/rank_list.R
+++ b/R/rank_list.R
@@ -44,6 +44,7 @@ as_label_tags <- function(labels) {
 #' @param labels A character vector with the text to display inside the widget.
 #'   This can also be a list of html tag elements.  The text content of each
 #'   label or label name will be used to set the shiny `input_id` value.
+#'   To create an empty `rank_list`, use `labels = list()`.
 #'
 #' @param text Text to appear at top of list.
 #'
@@ -140,10 +141,8 @@ dropNulls <- function(x) {
 }
 
 
-#' Change the value of a rank list.
+#' Change the text or labels of a rank list.
 #'
-#' At the moment, you can only update the `text` of the `rank_list`, not the
-#' labels.
 #'
 #' @inheritParams rank_list
 #' @param session The `session` object passed to function given to
@@ -154,7 +153,7 @@ dropNulls <- function(x) {
 #' ## Example of a shiny app that updates a bucket list and rank list
 #' if (interactive()) {
 #'   app <- system.file(
-#'     "shiny-examples/update/app.R",
+#'     "shiny-examples/update_rank_list/app.R",
 #'     package = "sortable"
 #'   )
 #'   shiny::runApp(app)

--- a/R/rank_list.R
+++ b/R/rank_list.R
@@ -116,7 +116,7 @@ rank_list <- function(
   rank_list_tags <- tagList(
     tags$div(
       class = paste("rank-list-container", paste(class, collapse = " ")),
-      id = paste0("rank-list-", css_id),
+      id = as_rank_list_id(css_id),
       title_tag,
       tags$div(
         class = "rank-list",
@@ -160,7 +160,7 @@ dropNulls <- function(x) {
 #' }
 update_rank_list <- function(css_id, text = NULL, labels = NULL,
                              session = shiny::getDefaultReactiveDomain()) {
-  inputId <- paste0("rank-list-", css_id)
+  inputId <- as_rank_list_id(css_id)
   if ( !is.null(labels) && length(labels) > 0) {
     labels <- as.character(tagList(as_label_tags(labels)))
   }
@@ -172,13 +172,14 @@ update_rank_list <- function(css_id, text = NULL, labels = NULL,
 
 #' Change the value of a bucket list.
 #'
-#' At the moment, you can only update the `text` of the `bucket_list`, not the
-#' labels.
+#' You can only update the `header` of the `bucket_list`.
+#' To update any of the labels or rank list text, use `update_rank_list()`
+#' instead.
 #'
 #' @inheritParams bucket_list
 #' @param session The `session` object passed to function given to
 #'   `shinyServer`.
-#' @seealso [bucket_list]
+#' @seealso [bucket_list], [update_rank_list]
 #' @export
 #' @examples
 #' ## Example of a shiny app that updates a bucket list and rank list

--- a/README.Rmd
+++ b/README.Rmd
@@ -15,7 +15,6 @@ knitr::opts_chunk$set(
 )
 ```
 
-
 # sortable <img src='man/figures/logo.png' align="right" height="139" />
 
 <!-- badges: start -->

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ ui <- fluidPage(
   )
 )
 
-server <- function(input, output) {
+server <- function(input, output, session) {
   output$results_basic <- renderPrint({
     input$rank_list_basic # This matches the input_id of the rank list
   })
@@ -156,7 +156,6 @@ students to classify objects into multiple categories.
 
 library(shiny)
 library(sortable)
-
 
 ui <- fluidPage(
   tags$head(
@@ -213,7 +212,7 @@ ui <- fluidPage(
   )
 )
 
-server <- function(input,output) {
+server <- function(input, output, session) {
   output$results_1 <-
     renderPrint(
       input$rank_list_1 # This matches the input_id of the first rank list
@@ -226,6 +225,7 @@ server <- function(input,output) {
     renderPrint(
       input$bucket_list_group # Matches the group_name of the bucket list
     )
+
 }
 
 

--- a/inst/htmlwidgets/plugins/sortable-rstudio/rank_list_binding.js
+++ b/inst/htmlwidgets/plugins/sortable-rstudio/rank_list_binding.js
@@ -4,29 +4,38 @@ var ranklistBinding = new Shiny.InputBinding();
 $.extend(ranklistBinding, {
 
   find: function(scope) {
-
     // find all instances of class rank-list-container
     return $(scope).find(".rank-list-container");
-
   },
 
   // this method will be called on initialization
-  initialize: function(el){
-
-  },
+  initialize: function(el){ },
 
   // this method will also be called on initialisation (to pass the intial state to input$...)
   // and each time when the callback is triggered via the event bound in subscribe
-  getValue: function(el) {
+  getValue: function(el) { },
+
+  setValue: function (el, data) {
+    // console.log(data);
+    if (data.text) {
+      $(el).find(".rank-list-title").text(data.text);
+    }
+
+    if (data.labels) {
+      const short_id = data.id.replace(/^rank-list-/, "");
+      $('#' + short_id).html(data.labels);
+      const label_ids = $('#' + short_id).children().map((idx, child) => {
+        return $(child).attr("data-rank-id") || $.trim(child.innerHTML);
+      }).toArray();
+      Shiny.setInputValue(short_id, label_ids, {priority: 'event'});
+    }
 
   },
 
-  subscribe: function(el, callback) {
-
-  },
+  subscribe: function(el, callback) { },
 
   receiveMessage: function(el, data) {
-    $(el).find(".rank-list-title").text(data.text);
+    this.setValue(el, data)
   }
 
 });

--- a/inst/htmlwidgets/plugins/sortable-rstudio/rank_list_binding.js
+++ b/inst/htmlwidgets/plugins/sortable-rstudio/rank_list_binding.js
@@ -35,7 +35,7 @@ $.extend(ranklistBinding, {
   subscribe: function(el, callback) { },
 
   receiveMessage: function(el, data) {
-    this.setValue(el, data)
+    this.setValue(el, data);
   }
 
 });
@@ -55,30 +55,29 @@ var bucketlistBinding = new Shiny.InputBinding();
 $.extend(bucketlistBinding, {
 
   find: function(scope) {
-
     // find all instances of class bucket-list-container
     return $(scope).find(".bucket-list-container");
-
   },
 
   // this method will be called on initialization
-  initialize: function(el){
-
-  },
+  initialize: function(el){ },
 
   // this method will also be called on initialisation (to pass the intial state to input$...)
   // and each time when the callback is triggered via the event bound in subscribe
-  getValue: function(el) {
+  getValue: function(el) { },
 
+  setValue: function (el, data) {
+    // console.log(data);
+    if (data.header) {
+      $(el).find(".bucket-list-header").text(data.header);
+    }
   },
 
-  subscribe: function(el, callback) {
 
-
-  },
+  subscribe: function(el, callback) { },
 
   receiveMessage: function(el, data) {
-    $(el).find(".bucket-list-header").text(data.header);
+    this.setValue(el, data);
   }
 
 });

--- a/inst/shiny-examples/update/app.R
+++ b/inst/shiny-examples/update/app.R
@@ -1,5 +1,5 @@
 ## ---- update-bucket-list-app -----------------------------------------------
-## Example shiny app with bucket list
+## Example shiny app with bucket list update
 
 library(shiny)
 library(sortable)

--- a/inst/shiny-examples/update_bucket_list/app.R
+++ b/inst/shiny-examples/update_bucket_list/app.R
@@ -1,0 +1,118 @@
+## ---- update-bucket-list-app -----------------------------------------------
+## Example shiny app with bucket list update
+
+library(shiny)
+library(sortable)
+library(magrittr)
+
+
+ui <- fluidPage(
+  tags$head(
+    tags$style(HTML(".bucket-list-container {min-height: 350px;}"))
+  ),
+  fluidRow(
+    column(
+      width = 12,
+      h2("Update the title"),
+      actionButton("btnUpdateBucket", label = "Update bucket list title"),
+      actionButton("btnAddLeft", label = "Add element to left"),
+      actionButton("btnMoveLeft", label = "Move element from right to left"),
+    )
+  ),
+  fluidRow(
+    column(
+      h2("Exercise"),
+      width = 12,
+      bucket_list(
+        header = "Drag the items in any desired bucket",
+        group_name = "bucket_list_group",
+        orientation = "horizontal",
+        add_rank_list(
+          text = "Drag from here",
+          labels = list(
+            "one",
+            "two",
+            "three"
+          ),
+          input_id = "rank_list_1"
+        ),
+        add_rank_list(
+          text = "to here",
+          labels = NULL,
+          input_id = "rank_list_2"
+        )
+      )
+    )
+  )
+)
+
+server <- function(input, output, session) {
+
+  # test updating the bucket list label
+  counter_bucket <- reactiveVal(1)
+  counter_option <- reactiveVal(3)
+  observe({
+    update_bucket_list(
+      "bucket_list_group",
+      header = paste("You pressed the update button", counter_bucket(), "times"),
+      session = session
+    )
+    counter_bucket(counter_bucket() + 1)
+  }) %>%
+    bindEvent(input$btnUpdateBucket)
+
+  observe({
+    len <- length(input$rank_list_1)
+    count_word <- if(len == 0) "" else glue::glue("({len})")
+    update_rank_list(
+      "rank_list_1",
+      text = paste0("From here ", count_word),
+      session = session
+    )
+  }) %>%
+    bindEvent(input$rank_list_1)
+
+  observe({
+    len <- length(input$rank_list_2)
+    count_word <- if(len == 0) "" else glue::glue("({len})")
+    update_rank_list(
+      "rank_list_2",
+      text = paste0("To here ", count_word),
+      session = session
+    )
+  }) %>%
+    bindEvent(input$rank_list_2)
+
+  # Respond to press of btnAddLeft
+  observe({
+    new_el <- paste("Element", counter_option() + 1)
+    counter_option(counter_option() + 1)
+    update_rank_list(
+      "rank_list_1",
+      labels = c(input$rank_list_1, new_el)
+    )
+  }) %>%
+    bindEvent(input$btnAddLeft)
+
+  # Respond to press of btnMoveLeft
+  observe({
+    bottom_el <- tail(input$rank_list_2, 1)
+    if (length(bottom_el)){
+      update_rank_list(
+        "rank_list_1",
+        labels = c(input$rank_list_1, bottom_el)
+      )
+      update_rank_list(
+        "rank_list_2",
+        labels = head(input$rank_list_2, -1)
+      )
+    }
+  }) %>%
+    bindEvent(input$btnMoveLeft)
+
+}
+
+
+
+
+shinyApp(ui, server)

--- a/inst/shiny-examples/update_bucket_list/app.R
+++ b/inst/shiny-examples/update_bucket_list/app.R
@@ -14,7 +14,7 @@ ui <- fluidPage(
     column(
       width = 12,
       h2("Update the title"),
-      actionButton("btnUpdateBucket", label = "Update bucket list title"),
+      actionButton("btnUpdateHeader", label = "Update bucket list header"),
       actionButton("btnAddLeft", label = "Add element to left"),
       actionButton("btnMoveLeft", label = "Move element from right to left"),
     )
@@ -51,6 +51,8 @@ server <- function(input, output, session) {
   # test updating the bucket list label
   counter_bucket <- reactiveVal(1)
   counter_option <- reactiveVal(3)
+
+  # Updates the bucket list header when btnUpdateHeader is pressed
   observe({
     update_bucket_list(
       "bucket_list_group",
@@ -59,8 +61,9 @@ server <- function(input, output, session) {
     )
     counter_bucket(counter_bucket() + 1)
   }) %>%
-    bindEvent(input$btnUpdateBucket)
+    bindEvent(input$btnUpdateHeader)
 
+  # Updates the rank list text with the number of labels
   observe({
     len <- length(input$rank_list_1)
     count_word <- if(len == 0) "" else glue::glue("({len})")
@@ -72,6 +75,7 @@ server <- function(input, output, session) {
   }) %>%
     bindEvent(input$rank_list_1)
 
+  # Updates the rank list text with the number of labels
   observe({
     len <- length(input$rank_list_2)
     count_word <- if(len == 0) "" else glue::glue("({len})")
@@ -83,7 +87,7 @@ server <- function(input, output, session) {
   }) %>%
     bindEvent(input$rank_list_2)
 
-  # Respond to press of btnAddLeft
+  # Respond to press of btnAddLeft and adds one new element to the left side
   observe({
     new_el <- paste("Element", counter_option() + 1)
     counter_option(counter_option() + 1)
@@ -94,7 +98,7 @@ server <- function(input, output, session) {
   }) %>%
     bindEvent(input$btnAddLeft)
 
-  # Respond to press of btnMoveLeft
+  # Respond to press of btnMoveLeft and moves the last element from R to L
   observe({
     bottom_el <- tail(input$rank_list_2, 1)
     if (length(bottom_el)){
@@ -111,8 +115,5 @@ server <- function(input, output, session) {
     bindEvent(input$btnMoveLeft)
 
 }
-
-
-
 
 shinyApp(ui, server)

--- a/inst/shiny-examples/update_rank_list/app.R
+++ b/inst/shiny-examples/update_rank_list/app.R
@@ -27,12 +27,15 @@ server <- function(input, output, session) {
     rv$data <- get(input$data)
   })
 
-  observeEvent(input$sortable, {
-    rv$data <- rv$data[input$sortable]
-  })
+  # observeEvent(input$sortable, {
+  #   rv$data <- rv$data[input$sortable]
+  # })
 
   output$sortable <- renderUI({
-    rank_list("Drag column names to change order", names(rv$data), "sortable")
+    rank_list(
+      "Drag column names to change order",
+      labels = names(rv$data),
+      input_id = "sortable")
   })
 
   output$table <- renderTable({

--- a/inst/shiny-examples/update_rank_list_method/app.R
+++ b/inst/shiny-examples/update_rank_list_method/app.R
@@ -1,0 +1,83 @@
+## ---- update-rank-list-method-app ---------------------------------------
+## Example shiny app that dynamically updates a rank list
+
+library(shiny)
+library(sortable)
+library(magrittr)
+
+
+ui <- fluidPage(
+  tags$head(
+    tags$style(HTML(".bucket-list-container {min-height: 350px;}"))
+  ),
+  fluidRow(
+    column(
+      width = 12,
+      h2("Modify a rank list"),
+      actionButton("btnUpdateRank", label = "Update rank list title"),
+      actionButton("btnChangeLabels", label = "Change labels"),
+      actionButton("btnSortLabels", label = "Sort labels"),
+      actionButton("btnEmptyLabels", label = "Empty labels")
+    )
+  ),
+  fluidRow(
+    column(
+      h2("Exercise"),
+      width = 12,
+        rank_list(
+          text = "Change the order",
+          labels = letters[1:5],
+          input_id = "rank_list_1"
+      )
+    )
+  ),
+  verbatimTextOutput("results")
+)
+
+server <- function(input, output, session) {
+
+  # test updating the bucket list label
+  counter_bucket <- reactiveVal(1)
+
+  output$results <- renderPrint({
+    input$rank_list_1 # This matches the input_id of the rank list
+  })
+
+  observe({
+    update_rank_list(
+      "rank_list_1",
+      text = paste("You pressed the update button", counter_bucket(), "times"),
+    )
+    counter_bucket(counter_bucket() + 1)
+  }) %>%
+    bindEvent(input$btnUpdateRank)
+
+
+  observe({
+    update_rank_list(
+      "rank_list_1",
+      labels = sample(LETTERS, 5)
+    )
+  }) %>%
+    bindEvent(input$btnChangeLabels)
+
+  observe({
+    update_rank_list(
+      "rank_list_1",
+      labels = list()
+    )
+  }) %>%
+    bindEvent(input$btnEmptyLabels)
+
+  observe({
+    update_rank_list(
+      "rank_list_1",
+      labels = sort(input$rank_list_1)
+    )
+  }) %>%
+    bindEvent(input$btnSortLabels)
+
+
+}
+
+shinyApp(ui, server)

--- a/man/add_rank_list.Rd
+++ b/man/add_rank_list.Rd
@@ -11,7 +11,8 @@ add_rank_list(text, labels = NULL, input_id = NULL, css_id = input_id, ...)
 
 \item{labels}{A character vector with the text to display inside the widget.
 This can also be a list of html tag elements.  The text content of each
-label or label name will be used to set the shiny \code{input_id} value.}
+label or label name will be used to set the shiny \code{input_id} value.
+To create an empty \code{rank_list}, use \code{labels = list()}.}
 
 \item{input_id}{output variable to read the plot/image from.}
 

--- a/man/rank_list.Rd
+++ b/man/rank_list.Rd
@@ -19,7 +19,8 @@ rank_list(
 
 \item{labels}{A character vector with the text to display inside the widget.
 This can also be a list of html tag elements.  The text content of each
-label or label name will be used to set the shiny \code{input_id} value.}
+label or label name will be used to set the shiny \code{input_id} value.
+To create an empty \code{rank_list}, use \code{labels = list()}.}
 
 \item{input_id}{output variable to read the plot/image from.}
 

--- a/man/update_bucket_list.Rd
+++ b/man/update_bucket_list.Rd
@@ -26,8 +26,9 @@ where you want the header to be empty - to do this use \code{header = NULL} or
 \code{shinyServer}.}
 }
 \description{
-At the moment, you can only update the \code{text} of the \code{bucket_list}, not the
-labels.
+You can only update the \code{header} of the \code{bucket_list}.
+To update any of the labels or rank list text, use \code{update_rank_list()}
+instead.
 }
 \examples{
 ## Example of a shiny app that updates a bucket list and rank list
@@ -40,5 +41,5 @@ if (interactive()) {
 }
 }
 \seealso{
-\link{bucket_list}
+\link{bucket_list}, \link{update_rank_list}
 }

--- a/man/update_rank_list.Rd
+++ b/man/update_rank_list.Rd
@@ -7,6 +7,7 @@
 update_rank_list(
   css_id,
   text = NULL,
+  labels = NULL,
   session = shiny::getDefaultReactiveDomain()
 )
 }
@@ -19,6 +20,10 @@ If NULL, the function generates an id of the form
 \code{rank_list_id_1}, and will automatically increment for every \code{rank_list}.}
 
 \item{text}{Text to appear at top of list.}
+
+\item{labels}{A character vector with the text to display inside the widget.
+This can also be a list of html tag elements.  The text content of each
+label or label name will be used to set the shiny \code{input_id} value.}
 
 \item{session}{The \code{session} object passed to function given to
 \code{shinyServer}.}

--- a/man/update_rank_list.Rd
+++ b/man/update_rank_list.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/rank_list.R
 \name{update_rank_list}
 \alias{update_rank_list}
-\title{Change the value of a rank list.}
+\title{Change the text or labels of a rank list.}
 \usage{
 update_rank_list(
   css_id,
@@ -23,20 +23,20 @@ If NULL, the function generates an id of the form
 
 \item{labels}{A character vector with the text to display inside the widget.
 This can also be a list of html tag elements.  The text content of each
-label or label name will be used to set the shiny \code{input_id} value.}
+label or label name will be used to set the shiny \code{input_id} value.
+To create an empty \code{rank_list}, use \code{labels = list()}.}
 
 \item{session}{The \code{session} object passed to function given to
 \code{shinyServer}.}
 }
 \description{
-At the moment, you can only update the \code{text} of the \code{rank_list}, not the
-labels.
+Change the text or labels of a rank list.
 }
 \examples{
 ## Example of a shiny app that updates a bucket list and rank list
 if (interactive()) {
   app <- system.file(
-    "shiny-examples/update/app.R",
+    "shiny-examples/update_rank_list/app.R",
     package = "sortable"
   )
   shiny::runApp(app)


### PR DESCRIPTION
This adds support for updating `rank_list` with the `update_rank_list()` function.

In particular:

- Allows updating of `text` as well as `labels`
- Allows clearing the labels using `labels = list()`
- Ensures correct handling of label tags
- Ensures the `rank_list` value updates when the labels are changed

This adds a dependency on `shiny (>= 1.9.0)` to use `Shiny.initializedPromise`  (see https://github.com/rstudio/shiny/blob/main/NEWS.md)

Closes #95